### PR TITLE
Add support for specifying URI scheme in env - promote to staging

### DIFF
--- a/bin/update_dashboard
+++ b/bin/update_dashboard
@@ -17,7 +17,7 @@ require 'faraday'
 require 'base64'
 require 'securerandom'
 require 'jwt'
-require 'URI'
+require 'uri'
 require 'pp'
 
 ##############################################################################

--- a/bin/update_dashboard
+++ b/bin/update_dashboard
@@ -17,6 +17,7 @@ require 'faraday'
 require 'base64'
 require 'securerandom'
 require 'jwt'
+require 'URI'
 require 'pp'
 
 ##############################################################################
@@ -181,7 +182,19 @@ check_required(pipeline_release_type, "Set PIPELINE_RELEASE_TYPE environment set
 check_required(source_pipeline_job_id, "Set CI_JOB_ID environment setting", 1)
 check_required(target_cloud, "Set CLOUD environment setting", 1)
 
-dashboard_api_url="https://#{dashboard_api_host_port}/api/source_key_project_monitor"
+# If protocol not set, default to https, otherwise use what's passed
+# NOTE: To use HTTP use `export DASHBOARD_API_HOST_PORT=http://apihost`
+uri = URI.parse(dashboard_api_host_port)
+case uri.scheme
+when 'https','http'
+  puts "NOTE: Using scheme #{uri.scheme} from #{dashboard_api_host_port}"
+  uristart=""
+else
+  puts "Using https with #{dashboard_api_host_port}"
+  uristart='https://'
+end
+
+dashboard_api_url="#{uristart}#{dashboard_api_host_port}/api/source_key_project_monitor"
 
 puts "Project build pipeline id: #{project_build_pipeline_id}"
 


### PR DESCRIPTION
Support setting URI scheme via DASHBOARD_API_HOST_PORT

- Default to https for URI scheme
  * example `export DASHBOARD_API_HOST_PORT=devapi.cncf.ci`
- If the environment variable DASHBOARD_API_HOST_PORT contains http or
https then that scheme will be used
  * example `export DASHBOARD_API_HOST_PORT=http://devapi.cncf.ci`