### PR TITLE
Maintenance - updating versions for kubectl, go, node used for cncfci docker images

### DIFF
--- a/debian-docker-go/Dockerfile
+++ b/debian-docker-go/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.12.1-stretch
+FROM golang:1.13.1-stretch
 
 RUN apt update \
     && apt install -y ca-certificates

--- a/debian-go-node-docker/Dockerfile
+++ b/debian-go-node-docker/Dockerfile
@@ -1,0 +1,47 @@
+FROM circleci/golang:1.13-node
+
+USER root
+
+RUN apt update \
+    && apt install -y ca-certificates
+
+#Install Ruby Deps
+
+RUN apt install -y patch bzip2 gawk patch zlib1g-dev libyaml-dev libsqlite3-dev sqlite3 autoconf libgdbm-dev libncurses5-dev automake libtool bison libffi-dev libgmp-dev libreadline6-dev
+#libssl1.0-dev
+RUN wget http://security.debian.org/debian-security/pool/updates/main/o/openssl1.0/libssl1.0.2_1.0.2t-1~deb9u1_amd64.deb && \
+apt install ./libssl1.0.2_1.0.2t-1~deb9u1_amd64.deb && \
+wget http://security.debian.org/debian-security/pool/updates/main/o/openssl1.0/libssl1.0-dev_1.0.2t-1~deb9u1_amd64.deb && \
+apt install ./libssl1.0-dev_1.0.2t-1~deb9u1_amd64.deb
+
+ENV DOCKER_CHANNEL edge
+ENV DOCKER_VERSION 17.11.0-ce
+
+RUN set -ex; \
+	apt install -y \
+		curl \
+		tar \
+    ; \
+  dockerArch='x86_64' \
+  ; \
+	if ! curl -fL -o docker.tgz "https://download.docker.com/linux/static/${DOCKER_CHANNEL}/${dockerArch}/docker-${DOCKER_VERSION}.tgz"; then \
+		echo >&2 "error: failed to download 'docker-${DOCKER_VERSION}' from '${DOCKER_CHANNEL}' for '${dockerArch}'"; \
+		exit 1; \
+	fi; \
+	\
+	tar --extract \
+		--file docker.tgz \
+		--strip-components 1 \
+		--directory /usr/local/bin/ \
+	; \
+	rm docker.tgz; \
+	dockerd -v; \
+	docker -v
+
+COPY modprobe.sh /usr/local/bin/modprobe
+COPY docker-entrypoint.sh /usr/local/bin/
+
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+
+ENTRYPOINT ["docker-entrypoint.sh"]
+CMD ["sh"]

--- a/debian-go-node-docker/docker-entrypoint.sh
+++ b/debian-go-node-docker/docker-entrypoint.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+set -e
+
+# first arg is `-f` or `--some-option`
+if [ "${1#-}" != "$1" ]; then
+	  set -- docker "$@"
+fi
+
+# if our command is a valid Docker subcommand, let's invoke it through Docker instead
+# (this allows for "docker run docker ps", etc)
+if docker help "$1" > /dev/null 2>&1; then
+	  set -- docker "$@"
+fi
+
+# if we have "--link some-docker:docker" and not DOCKER_HOST, let's set DOCKER_HOST automatically
+if [ -z "$DOCKER_HOST" -a "$DOCKER_PORT_2375_TCP" ]; then
+	  export DOCKER_HOST='tcp://docker:2375'
+fi
+
+if [ "$1" = 'dockerd' ]; then
+	  cat >&2 <<-'EOW'
+		📎 Hey there!  It looks like you're trying to run a Docker daemon.
+		   You probably should use the "dind" image variant instead, something like:
+		     docker run --privileged --name some-overlay-docker -d docker:stable-dind --storage-driver=overlay
+		   See https://hub.docker.com/_/docker/ for more documentation and usage examples.
+	EOW
+	  sleep 3
+fi
+
+exec "$@"

--- a/debian-go-node-docker/modprobe.sh
+++ b/debian-go-node-docker/modprobe.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+set -eu
+
+# "modprobe" without modprobe
+# https://twitter.com/lucabruno/status/902934379835662336
+
+# this isn't 100% fool-proof, but it'll have a much higher success rate than simply using the "real" modprobe
+
+# Docker often uses "modprobe -va foo bar baz"
+# so we ignore modules that start with "-"
+for module; do
+	  if [ "${module#-}" = "$module" ]; then
+		    ip link show "$module" || true
+		    lsmod | grep "$module" || true
+	  fi
+done
+
+# remove /usr/local/... from PATH so we can exec the real modprobe as a last resort
+export PATH='/usr/sbin:/usr/bin:/sbin:/bin'
+exec modprobe "$@"

--- a/debian-go/Dockerfile
+++ b/debian-go/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.13-rc-buster
+FROM golang:1.12.6-stretch
 
 #Install Ruby Deps
 

--- a/debian-go/Dockerfile
+++ b/debian-go/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.11.4-stretch
+FROM golang:1.13-rc-buster
 
 #Install Ruby Deps
 

--- a/debian-go/Dockerfile
+++ b/debian-go/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.12.6-stretch
+FROM golang:1.13.1-stretch
 
 #Install Ruby Deps
 

--- a/debian-helm-kubectl/Dockerfile
+++ b/debian-helm-kubectl/Dockerfile
@@ -1,8 +1,8 @@
 FROM buildpack-deps:stretch
 
-ARG VERSION=v2.13.1
+ARG VERSION=v2.14.3
 ARG FILENAME=helm-${VERSION}-linux-amd64.tar.gz
-ARG KUBECTL=v1.13.0
+ARG KUBECTL=v1.16.2
 
 WORKDIR /
 


### PR DESCRIPTION
## Description

Maintenance to update kubectl and go versions. Images pushed to dockerhub

## Motivation and Context


## How Has This Been Tested?
* [ ]  Covered by existing integration testing
* [ ]  Added integration testing to cover
* [x] Tested with [trigger client](https://github.com/crosscloudci/crosscloudci-trigger) against 
   * [x] cidev.cncf.ci
   * [x] dev.cncf.ci
   * [ ] staging.cncf.ci
   * [ ] cncf.ci (production)
* [x]  Tested locally
* [ ]  Have not tested

## Types of changes
* [ ]  Bug fix (non-breaking change which fixes an issue)
* [x]  New feature (non-breaking change which adds functionality)
* [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
 
## Checklist:
* [ ]  My change requires a change to the documentation.
* [ ]  I have updated the documentation accordingly.